### PR TITLE
Pin shared workflow refs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build:
     if: github.ref != 'refs/heads/main' || github.event_name == 'pull_request'
-    uses: zavestudios/platform-pipelines/.github/workflows/hugo-build.yml@main
+    uses: zavestudios/platform-pipelines/.github/workflows/hugo-build.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
     with:
       goprivate: github.com/zavestudios/*,gitlab.com/platformystical/*
       gonosumdb: github.com/zavestudios/*,gitlab.com/platformystical/*
@@ -31,11 +31,11 @@ jobs:
   deploy:
     name: Deploy Hugo Site
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    uses: zavestudios/platform-pipelines/.github/workflows/hugo-deploy.yml@main
+    uses: zavestudios/platform-pipelines/.github/workflows/hugo-deploy.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
     with:
       goprivate: github.com/zavestudios/*,gitlab.com/platformystical/*
       gonosumdb: github.com/zavestudios/*,gitlab.com/platformystical/*
 
   link-check:
     name: Check Markdown Links
-    uses: zavestudios/platform-pipelines/.github/workflows/link-check.yml@main
+    uses: zavestudios/platform-pipelines/.github/workflows/link-check.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -1,0 +1,17 @@
+name: Workflow Validation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  validate-workflows:
+    name: Validate GitHub Actions Workflows
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@1a17b8c97621a09b71d50f5493638df902468c9e


### PR DESCRIPTION
## Summary
- replace floating `platform-pipelines` workflow refs with an immutable commit SHA in the Pages workflow

## Testing
- workflow reference change only; GitHub Actions validation will run on the PR

## Notes
- pins shared workflow refs to `c0aa80bb405fa24ede5ebcf1c40b0be90328386c`