### PR TITLE
Add workflow validation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,8 +13,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -31,6 +29,10 @@ jobs:
   deploy:
     name: Deploy Hugo Site
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: zavestudios/platform-pipelines/.github/workflows/hugo-deploy.yml@c0aa80bb405fa24ede5ebcf1c40b0be90328386c
     with:
       goprivate: github.com/zavestudios/*,gitlab.com/platformystical/*

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -20,4 +20,4 @@ permissions:
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
-    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@1a17b8c97621a09b71d50f5493638df902468c9e
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0be73c38bcf2e02dc220a2969d4619b4d49d446a

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -20,4 +20,4 @@ permissions:
 jobs:
   validate-workflows:
     name: Validate GitHub Actions Workflows
-    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0be73c38bcf2e02dc220a2969d4619b4d49d446a
+    uses: zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@a05c4ffcb25a40f874c92b9d17187be031e84eaf


### PR DESCRIPTION
## Summary
- add `workflow-validation.yml` to run the shared `platform-pipelines` workflow validator
- grant the permissions required by the reusable validator and its smoke jobs
- point the validator at the self-contained `platform-pipelines` workflow commit

## Why
PR #93 already merged the SHA pinning change. This follow-up PR carries only the new workflow validation job and its permission/ref fixes.

## Testing
- GitHub Actions will validate the workflow on this PR

## Notes
- validator pinned to `zavestudios/platform-pipelines/.github/workflows/workflow-ci.yml@0be73c38bcf2e02dc220a2969d4619b4d49d446a`